### PR TITLE
Fix up builder pattern example a little

### DIFF
--- a/0201-property-mapping.md
+++ b/0201-property-mapping.md
@@ -116,14 +116,14 @@ Sfm will look for a static method that return a type that will return the builde
 
 {% highlight java %}
 class MyClass {
-   public static MyClassBuilder builder {
+   public static MyClassBuilder builder() {
    ...
    }
 
    public static class MyClassBuilder {
-        MyClassBuilder value(String value) {}
+        MyClassBuilder property1(String value) {}
         MyClassBuilder index(int value) {}
-        MyClass builde() {}
+        MyClass build() {}
    }
 }
 {% endhighlight %}
@@ -133,8 +133,8 @@ It is also possible to manually specify the method/constructor to instantiate th
 {% highlight java %}
 mapperFactory.newMapper(
     mapperFactory.getClassMetaWithExtraInstantiator(
-        IClass.class, 
-        IClassBuilder.class.getConstructor()));
+        MyClass.class, 
+        MyClassBuilder.class.getConstructor()));
 {% endhighlight %}
 
 ## finals 


### PR DESCRIPTION
I think this is correct. The `builder` method needs to have the `()` to be a valid function. And I changed the `value` function on the building to `property1` to indicate the name should match a property.